### PR TITLE
Bump runtime

### DIFF
--- a/org.gnome.Taquin.json
+++ b/org.gnome.Taquin.json
@@ -1,7 +1,7 @@
 {
     "app-id": "org.gnome.Taquin",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "40",
+    "runtime-version": "42",
     "sdk": "org.gnome.Sdk",
     "command": "gnome-taquin",
     "finish-args": [
@@ -17,13 +17,17 @@
         "shared-modules/libcanberra/libcanberra.json",
         {
             "name" : "gsound",
-            "buildsystem" : "autotools",
+            "buildsystem": "meson",
+            "builddir": true,
             "sources" : [
                 {
                     "type" : "archive",
-                    "url" : "https://download.gnome.org/sources/gsound/1.0/gsound-1.0.2.tar.xz",
-                    "sha256": "bba8ff30eea815037e53bee727bbd5f0b6a2e74d452a7711b819a7c444e78e53"
+                    "url" : "https://download.gnome.org/sources/gsound/1.0/gsound-1.0.3.tar.xz",
+                    "sha256" : "ca2d039e1ebd148647017a7f548862350bc9af01986d39f10cfdc8e95f07881a"
                 }
+            ],
+            "cleanup" : [
+                "/bin"
             ]
         },
         {

--- a/org.gnome.Taquin.json
+++ b/org.gnome.Taquin.json
@@ -18,7 +18,6 @@
         {
             "name" : "gsound",
             "buildsystem": "meson",
-            "builddir": true,
             "sources" : [
                 {
                     "type" : "archive",


### PR DESCRIPTION
Gsound dropped autotools in https://gitlab.gnome.org/GNOME/gsound/-/commit/463f4fa6a17d66fe664cd89dbc1a0863cb582ec4

Hi, @bilelmoussaoui, please review when you have time. Thanks!